### PR TITLE
Added and fixed some sensors for d3 type of feeder

### DIFF
--- a/custom_components/petkit/__init__.py
+++ b/custom_components/petkit/__init__.py
@@ -394,11 +394,9 @@ class FeederDevice(PetkitDevice):
 
     @property
     def feed_times(self):
-        if self.device_type == "d3":
+        if self.device_type == 'd3':
             times = self.feed_state_attrs().get('feedTimes', [])
             return len(times)
-             
-
         return self.feed_state_attrs().get('times', 0)
 
     @property
@@ -420,7 +418,6 @@ class FeederDevice(PetkitDevice):
     @property
     def bowl_weight(self):
         return self.status.get('weight', 0)
-
 
     @property
     def feeding(self):

--- a/custom_components/petkit/__init__.py
+++ b/custom_components/petkit/__init__.py
@@ -447,8 +447,7 @@ class FeederDevice(PetkitDevice):
 
     @property
     def hass_sensor(self):
-        if self.device_type == "d3":
-            return {
+        dat = {
                 **super().hass_sensor,
                 'desiccant': {
                     'unit': 'days',
@@ -464,42 +463,23 @@ class FeederDevice(PetkitDevice):
                     'icon': 'mdi:weight-gram',
                     'state_attrs': self.feed_state_attrs,
                 },
+            }
+        if self.device_type == 'd3':
+            dat.update({
                 'eat_amount': {
                     'unit': 'g',
                     'icon': 'mdi:weight-gram',
-                    'state_attrs': self.feed_state_attrs,
                 },
                 'eat_times': {
                     'unit': 'times',
                     'icon': 'mdi:counter',
-                    'state_attrs': self.feed_state_attrs,
                 },
                 'bowl_weight': {
                     'unit': 'g',
                     'icon': 'mdi:weight-gram',
-                    'state_attrs': self.state_attrs,
                 },
-            }
-
-        else:
-            return {
-                **super().hass_sensor,
-                'desiccant': {
-                    'unit': 'days',
-                    'icon': 'mdi:air-filter',
-                },
-                'feed_times': {
-                    'unit': 'times',
-                    'icon': 'mdi:counter',
-                    'state_attrs': self.feed_state_attrs,
-                },
-                'feed_amount': {
-                    'unit': 'g',
-                    'icon': 'mdi:weight-gram',
-                    'state_attrs': self.feed_state_attrs,
-                },
-            }
-
+            })
+        return dat
 
     @property
     def hass_binary_sensor(self):

--- a/custom_components/petkit/__init__.py
+++ b/custom_components/petkit/__init__.py
@@ -394,6 +394,11 @@ class FeederDevice(PetkitDevice):
 
     @property
     def feed_times(self):
+        if self.device_type == "d3":
+            times = self.feed_state_attrs().get('feedTimes', [])
+            return len(times)
+             
+
         return self.feed_state_attrs().get('times', 0)
 
     @property
@@ -402,6 +407,20 @@ class FeederDevice(PetkitDevice):
 
     def feed_state_attrs(self):
         return self.detail.get('state', {}).get('feedState') or {}
+
+    @property
+    def eat_amount(self):
+        return self.feed_state_attrs().get('eatAmountTotal', 0)
+
+    @property
+    def eat_times(self):
+        times = self.feed_state_attrs().get('eatTimes', [])
+        return len(times)
+
+    @property
+    def bowl_weight(self):
+        return self.status.get('weight', 0)
+
 
     @property
     def feeding(self):
@@ -431,23 +450,59 @@ class FeederDevice(PetkitDevice):
 
     @property
     def hass_sensor(self):
-        return {
-            **super().hass_sensor,
-            'desiccant': {
-                'unit': 'days',
-                'icon': 'mdi:air-filter',
-            },
-            'feed_times': {
-                'unit': 'times',
-                'icon': 'mdi:counter',
-                'state_attrs': self.feed_state_attrs,
-            },
-            'feed_amount': {
-                'unit': 'g',
-                'icon': 'mdi:weight-gram',
-                'state_attrs': self.feed_state_attrs,
-            },
-        }
+        if self.device_type == "d3":
+            return {
+                **super().hass_sensor,
+                'desiccant': {
+                    'unit': 'days',
+                    'icon': 'mdi:air-filter',
+                },
+                'feed_times': {
+                    'unit': 'times',
+                    'icon': 'mdi:counter',
+                    'state_attrs': self.feed_state_attrs,
+                },
+                'feed_amount': {
+                    'unit': 'g',
+                    'icon': 'mdi:weight-gram',
+                    'state_attrs': self.feed_state_attrs,
+                },
+                'eat_amount': {
+                    'unit': 'g',
+                    'icon': 'mdi:weight-gram',
+                    'state_attrs': self.feed_state_attrs,
+                },
+                'eat_times': {
+                    'unit': 'times',
+                    'icon': 'mdi:counter',
+                    'state_attrs': self.feed_state_attrs,
+                },
+                'bowl_weight': {
+                    'unit': 'g',
+                    'icon': 'mdi:weight-gram',
+                    'state_attrs': self.state_attrs,
+                },
+            }
+
+        else:
+            return {
+                **super().hass_sensor,
+                'desiccant': {
+                    'unit': 'days',
+                    'icon': 'mdi:air-filter',
+                },
+                'feed_times': {
+                    'unit': 'times',
+                    'icon': 'mdi:counter',
+                    'state_attrs': self.feed_state_attrs,
+                },
+                'feed_amount': {
+                    'unit': 'g',
+                    'icon': 'mdi:weight-gram',
+                    'state_attrs': self.feed_state_attrs,
+                },
+            }
+
 
     @property
     def hass_binary_sensor(self):


### PR DESCRIPTION
I fixed the feed_count sensor and added a few additional sensors the d3 offers, like the number of times the pet has eaten, and the total eaten amount, and weight of the bowl

Here's what I get in HA from my D3 feeder now:

<img width="496" alt="Screen Shot 2022-01-23 at 12 23 34 PM" src="https://user-images.githubusercontent.com/12651/150692488-c2753044-e70c-4beb-912e-32a476f17f77.png">

