### PR TITLE
fixed get petWeight

### DIFF
--- a/custom_components/petkit/__init__.py
+++ b/custom_components/petkit/__init__.py
@@ -1,4 +1,5 @@
 """The component."""
+import copy
 import logging
 import hashlib
 import datetime
@@ -620,14 +621,14 @@ class LitterDevice(PetkitDevice):
         return dic.get(evt, evt)
 
     def last_record_attrs(self, only_event=None):
-        rls = self.records
+        rls = copy.deepcopy(self.records)
         if not rls:
             return {}
         lst = rls[-1] or {}
         if only_event:
             rls.reverse()
             for v in rls:
-                if only_event == v.get('eventType'):
+                if only_event == v.get('eventType') and v.get('content'):
                     lst = v
                     break
         ctx = lst.pop('content', None) or {}


### PR DESCRIPTION
#30 #29 

The `def pet_weight(self)` function will be called twice when update, and `rls.reverse()` will also be called twice. So we will get the pet weight from the earlier record.

What's worse is that the `content` will be popped out at the first call, and we may cann't get `content.petWeight`.

I use a copy to avoid the interaction between each call. This may not be an elegant approach, but it works.